### PR TITLE
Add SAR application to stop mail storms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - python -m pyflakes .
 
     - language: node_js
-      nodejs:
+      node_js:
         - 12
       before_install:
         - cd workmail-stop-mail-storm/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
-language: python
-python: 
-  - "3.6"
-  - "3.7"
-install:
-- pip install -r requirements.txt
-script:
-- python -m pyflakes .
+matrix:
+  include:
+    - language: python
+      python:
+        - "3.6"
+        - "3.7"
+      install:
+        - pip install -r requirements.txt
+      script:
+        - python -m pyflakes .
+
+    - language: nodejs
+      nodejs:
+        - 12
+      before_install:
+        - cd workmail-stop-mail-storm/src
+      install:
+        - npm install
+      script:
+        - npm run jshint

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,20 @@ matrix:
     - language: python
       python:
         - "3.6"
+      install:
+        - pip install -r requirements.txt
+      script:
+        - python -m pyflakes .
+
+    - language: python
+      python:
         - "3.7"
       install:
         - pip install -r requirements.txt
       script:
         - python -m pyflakes .
 
-    - language: nodejs
+    - language: node_js
       nodejs:
         - 12
       before_install:

--- a/workmail-stop-mail-storm/README.md
+++ b/workmail-stop-mail-storm/README.md
@@ -1,0 +1,79 @@
+# Email Storm protection application for Amazon WorkMail
+
+An [email storm](https://en.wikipedia.org/wiki/Email_storm) is a sudden spike of messages on an email distribution list. This can cause hundreds of messages to flood user mailboxes.
+ 
+This application helps you protect [Amazon WorkMail Groups](https://docs.aws.amazon.com/workmail/latest/adminguide/groups_overview.html) within your organization from email storms. It is built on top of the [Run Lambda Email Flow Rules](https://docs.aws.amazon.com/workmail/latest/adminguide/lambda.html#synchronous-rules) for Amazon WorkMail.
+
+### Setup
+
+1. Deploy the application from the [AWS Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:489970191081:applications~workmail-stop-mail-storm). Provide the following items:
+    1. The email addresses that you want to protect from email storms
+    1. The threshold of emails per minute
+1. Open the [Amazon WorkMail Console](https://console.aws.amazon.com/workmail/) and create a [RunLambda Email Flow Rule](https://docs.aws.amazon.com/workmail/latest/adminguide/lambda.html#synchronous-rules) that uses the AWS Lambda function you created in step 1.
+
+You now have a working Lambda function that is triggered by Amazon WorkMail based on the rule you created.
+
+### How does it work?
+
+For each protected Amazon WorkMail group, the application creates an [Amazon CloudWatch metric](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html) that counts the number of emails received per minute. The application also creates an [Amazon CloudWatch alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html) with a user-configured threshold on that metric.
+
+When an email is received by a protected group, the application publishes a data point for the metric created for the group and verifies the alarm state. If the alarm is in ALARM state then the email is bounced before it is distributed.
+
+### Customizing your Lambda function
+You can customize your Lambda function by editing and testing it in the [AWS Lambda Console](https://console.aws.amazon.com/lambda/home) built-in code editor. For more information on the code editor, see [here](https://docs.aws.amazon.com/lambda/latest/dg/code-editor.html).
+
+You can modify the alarm conditions [here](https://github.com/aws-samples/amazon-workmail-lambda-templates/blob/master/workmail-stop-mail-storm/src/app.py#L51). For more information, see [CloudWatch alarms documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html).
+
+For more advanced use cases, such as changing your AWS CloudFormation template to create additional AWS resources that will support this application, see [Local development](#local-development)
+
+### Costs, performance and availability considerations
+This application emits a metric and queries the alarm state for each email received by a protected email address. Each of these actions can incur [extra costs](https://aws.amazon.com/cloudwatch/pricing/).
+
+Each CloudWatch action also adds a delay, usually less than one second. The actions can fail if the CloudWatch or Lambda service fails. Potential delays and failures are mitigated by timeouts and retry limits configured in Amazon WorkMail and your Lambda function. For more information, see [Configuring AWS Lambda for Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/adminguide/lambda.html#synchronous-rules) in the Amazon WorkMail Administration Guide.
+
+The DescribeAlarms API used to verify CloudWatch alarms is limited to nine requests per second. If you need a higher threshold, you can [request a quota increase](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html).
+
+## Local development
+Cloning this repository from [GitHub](https://github.com/aws-samples/amazon-workmail-lambda-templates).
+
+If you are not familiar with CloudFormation templates, see [Learn Template Basics](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/gettingstarted.templatebasics.html).
+
+1. Create additional resources for your application by changing [template.yaml](https://github.com/aws-samples/workmail-stop-mail-storm/blob/master/workmail-stop-mail-storm/template.yaml). For more information, see [Template Reference in the AWS CloudFormation User Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-reference.html).
+2. Modify your Lambda function by changing [app.py](https://github.com/aws-samples/amazon-workmail-lambda-templates/blob/master/workmail-stop-mail-storm/src/app.py).
+3. Test your Lambda function locally by completing the following tasks:
+    1. [Set up the SAM CLI](https://aws.amazon.com/serverless/sam/).
+    2. Configure a test event at `event.json`.
+    3. Invoke your Lambda function locally using:
+        `sam local invoke -e tst/event.json -n tst/environment_variables.json`
+
+After you validated the behavior of your Lambda function, you are ready to deploy it.
+
+### Deploying a local version
+This step bundles all your code and configuration to your S3 bucket.
+
+```bash
+sam package \
+ --template-file template.yaml \
+ --output-template-file packaged.yaml \
+ --s3-bucket $YOUR_BUCKET_NAME
+```
+
+This step updates your CloudFormation stack to reflect the changes you made, which will in turn updates the changes made in your Lambda function.
+```bash
+sam deploy \
+ --template-file packaged.yaml \
+ --stack-name workmail-stop-mail-storm \
+ --capabilities CAPABILITY_IAM
+```
+Your Lambda function is now deployed. You can now configure Amazon WorkMail to trigger this function on inbound email.
+
+### Configure Amazon WorkMail
+To use this Lambda with Amazon WorkMail, use the [Amazon WorkMail Console](https://console.aws.amazon.com/workmail/) to create a **RunLambda** [email flow rule](https://docs.aws.amazon.com/workmail/latest/adminguide/create-email-rules.html). [Configuring AWS Lambda for Amazon WorkMail](https://docs.aws.amazon.com/workmail/latest/adminguide/lambda.html#synchronous-rules) in the Amazon WorkMail Administration Guide. 
+
+These steps will require the full ARN of your Lambda function. Get the ARN by running the following command:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name workmail-stop-mail-storm \
+  --query 'Stacks[].Outputs[0].OutputValue'
+```

--- a/workmail-stop-mail-storm/src/app.js
+++ b/workmail-stop-mail-storm/src/app.js
@@ -1,0 +1,152 @@
+/* jshint node: true, esversion: 9 */
+'use strict';
+const AWS = require('aws-sdk'); // this is automatically installed in your lambda environment
+const cloudwatch = new AWS.CloudWatch(); // uses your lambda credentials to call Cloudwatch
+
+const ALARM_PREFIX = 'EmailsReceived-';
+const DEFAULT_THRESHOLD = 20; // in case environment variable THRESHOLD is missing.
+
+async function emitNewMetric(protectedRecipients) {
+    // see https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html for detailed
+    // explanation of the parameters
+    const params = {
+        Namespace: 'WorkMail',
+        MetricData: protectedRecipients.map(protectedRecipient =>
+            ({
+                MetricName: 'EmailsReceived',
+                Dimensions: [
+                    {
+                        Name: 'EmailAddress',
+                        Value: protectedRecipient
+                    }
+                ],
+                Unit: 'Count',
+                Value: 1
+            }))
+    };
+
+    // it is important that we emit the metric even if we block this sending later
+    // otherwise, the alarm would clear after 5 mins, people would be able to continue the storm for a while again
+    // that would lead to a on-off-on-off pattern, which still lets too much junk through
+
+    await cloudwatch.putMetricData(params).promise();
+    console.log('Finished putMetricData');
+}
+
+async function createMissingAlarms(alarms, protectedRecipients) {
+    // find the protected addresses for which there is already an alarm
+    const protectedAddressesWithAlarm = alarms.MetricAlarms
+        .map(metricAlarm => metricAlarm.Dimensions[0].Value);
+
+    // remove those from all alarms. the remaining addresses are missing alarms
+    const protectedAddressesMissingAlarm = protectedRecipients
+        .filter(protectedAddress => !protectedAddressesWithAlarm.includes(protectedAddress));
+
+    // create the alarm for those
+    for (let protectedAddress of protectedAddressesMissingAlarm) {
+        // this will create an alarm that will fire if we receive in 3 different minutes more than THRESHOLD emails
+        // per minute, in a window of the last 5 minutes.
+
+        // see https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html for detailed
+        // explanation of the parameters
+        const params = {
+            AlarmName: ALARM_PREFIX + protectedAddress,
+            ComparisonOperator: 'GreaterThanThreshold',
+            AlarmDescription: 'Mail storm in progress for group ' + protectedAddress,
+            Dimensions: [
+                {
+                    Name: 'EmailAddress',
+                    Value: protectedAddress
+                },
+            ],
+            MetricName: 'EmailsReceived',
+            Namespace: 'WorkMail',
+            TreatMissingData: 'notBreaching',
+            // The parameters below control how sensitive the detection for mailstorm is.
+            DatapointsToAlarm: 3, // alarm if 3 of the last 5 datapoints are above threshold
+            EvaluationPeriods: 5,
+            Period: 60, // each data point for evaluation is a sum of emails received in the last 60 s.
+            Statistic: 'Sum',
+            // configure using the THRESHOLD lambda environment variable
+            Threshold: parseInt(process.env.THRESHOLD || DEFAULT_THRESHOLD),
+
+        };
+        console.log('Creating alarm for address ' + protectedAddress);
+        const alarm = await cloudwatch.putMetricAlarm(params).promise();
+        console.log(alarm);
+    }
+}
+
+async function verifyAlarms(protectedRecipients) {
+    // see https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html for detailed
+    // explanation of the parameters
+    const params = {
+        AlarmNames: protectedRecipients.map(protectedAddress => ALARM_PREFIX + protectedAddress),
+        AlarmTypes: ['MetricAlarm'],
+    };
+
+    const allAlarms = await cloudwatch.describeAlarms(params).promise();
+    console.log('Finished describeAlarms - Results:');
+    console.log(allAlarms);
+
+    const protectedAddressesInAlarm = allAlarms.MetricAlarms
+        .filter(metricAlarm => metricAlarm.StateValue === 'ALARM')
+        .map(metricAlarm => metricAlarm.Dimensions[0].Value);
+
+    return {allAlarms, protectedAddressesInAlarm};
+}
+
+exports.lambdaHandler = async (event) => {
+    console.log('Event received by lambda function:');
+    console.log(JSON.stringify(event)); // see event documentation in https://docs.aws.amazon.com/workmail/latest/adminguide/lambda.html
+    console.log('Environment variables:');
+    console.log(JSON.stringify(process.env));
+
+    // split on comma, and cleanup whitespace around
+    const allProtectedAddresses = (process.env.PROTECTED_ADDRESSES || '')
+        .split(',').map(address => address.trim());
+
+    console.log('Email addresses to protect against mail storms: ' + allProtectedAddresses);
+
+    // take only the email address of each recipient
+    const recipients = event.envelope.recipients.map(recipient => recipient.address);
+
+    // find the protected recipients among all recipients
+    const protectedRecipients = recipients.filter(recipient => allProtectedAddresses.includes(recipient));
+
+    // in this case, we can simply let the email pass, and avoid looking at all alarms
+    if (protectedRecipients.length === 0) {
+        console.log('No recipient in this email is protected against mail storm. Letting the email pass.');
+        return {
+            actions: [
+                {
+                    allRecipients: true,        // for all recipients
+                    action: {type: 'DEFAULT'}   // let the email be sent normally
+                }
+            ]
+        };
+    }
+
+    await emitNewMetric(protectedRecipients);
+    const {allAlarms, protectedAddressesInAlarm} = await verifyAlarms(protectedRecipients);
+
+    // an alarm can be missing for a protected address if it is the first time we receive an email for it
+    await createMissingAlarms(allAlarms, protectedRecipients);
+
+    if (protectedAddressesInAlarm.length > 0) {
+        console.log('Bouncing email from ' + event.envelope.mailFrom.address + ' to ' + protectedAddressesInAlarm);
+    }
+
+    return {
+        actions: [
+            {
+                recipients: protectedAddressesInAlarm,  // for the recipients in alarm
+                action: {type: 'BOUNCE'},               // make it bounce
+            },
+            {
+                allRecipients: true,                    // for all the other recipients
+                action: {type: 'DEFAULT'},              // let the email pass normally
+            }
+        ]
+    };
+};

--- a/workmail-stop-mail-storm/src/package.json
+++ b/workmail-stop-mail-storm/src/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "workmail-stop-mail-storm",
+  "version": "1.0.0",
+  "description": "A sample lambda email flow rule for Amazon WorkMail, intended to stop mail storms to large groups. For more information, visit https://github.com/aws-samples/amazon-workmail-lambda-templates",
+  "main": "app.js",
+  "scripts": {
+    "jshint": "jshint *.js",
+    "test": "sam build -t ../template.yaml && sam local invoke -e ../tst/event.json -n ../tst/environment_variables.json"
+  },
+  "author": "Amazon WorkMail",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "jshint": "^2.11.0"
+  }
+}

--- a/workmail-stop-mail-storm/template.yaml
+++ b/workmail-stop-mail-storm/template.yaml
@@ -1,0 +1,68 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Lambda function to stop mail storms using WorkMail rules
+    
+Parameters:
+    ProtectedAddresses:
+        Type: CommaDelimitedList
+        Default: ''
+        Description: "List of email addresses to stop mail storms, comma-separated. Example: big_group1@example.com, big_group2@example.com"
+    MailStormThreshold:
+        Type: Number
+        MinValue: 1
+        MaxValue: 10000
+        Description: "Threshold of number of emails per minute that will trigger the mail storm protection"
+
+Resources:
+    StopMailStormFunction:
+        Type: AWS::Serverless::Function
+        Properties:
+            CodeUri: src/
+            Handler: app.lambdaHandler
+            Runtime: nodejs12.x
+            Timeout: 10
+            Role: !GetAtt StopMailStormFunctionRole.Arn
+            Environment:
+                Variables:
+                    PROTECTED_ADDRESSES: !Join [ ",", !Ref ProtectedAddresses ]
+                    THRESHOLD: !Ref MailStormThreshold
+
+    StopMailStormFunctionRole:
+        Type: AWS::IAM::Role
+        Properties:
+            AssumeRolePolicyDocument:
+                Statement:
+                    - Action:
+                          - sts:AssumeRole
+                      Effect: Allow
+                      Principal:
+                          Service:
+                              - "lambda.amazonaws.com"
+                Version: "2012-10-17"
+            Path: "/"
+            ManagedPolicyArns:
+                - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+            Policies:
+                - PolicyName: "allow-cloudwatch-actions"
+                  PolicyDocument:
+                      Version: "2012-10-17"
+                      Statement:
+                          - Effect: "Allow"
+                            Action:
+                                - "cloudwatch:PutMetricData"
+                                - "cloudwatch:PutMetricAlarm"
+                                - "cloudwatch:DescribeAlarms"
+                            Resource: "*"
+
+
+    PermissionToCallLambda:
+        Type: AWS::Lambda::Permission
+        DependsOn: StopMailStormFunction
+        Properties:
+            Action: lambda:InvokeFunction
+            FunctionName: !Ref StopMailStormFunction
+            Principal: !Sub 'workmail.${AWS::Region}.amazonaws.com'
+
+Outputs:
+    StopMailStormFunctionArn:
+        Value: !GetAtt StopMailStormFunction.Arn

--- a/workmail-stop-mail-storm/tst/environment_variables.json
+++ b/workmail-stop-mail-storm/tst/environment_variables.json
@@ -1,0 +1,6 @@
+{
+    "StopMailStormFunction": {
+        "PROTECTED_ADDRESSES": "big_group1@domain.test, big_group2@domain.test",
+        "THRESHOLD": 20
+    }
+}

--- a/workmail-stop-mail-storm/tst/event.json
+++ b/workmail-stop-mail-storm/tst/event.json
@@ -1,0 +1,20 @@
+{
+    "summaryVersion": "2018-10-10",
+    "envelope": {
+        "mailFrom" : {
+            "address" : "from@domain.test"
+        },
+        "recipients" : [
+           { "address" : "recipient1@domain.test" },
+           { "address" : "big_group1@domain.test" }
+        ]
+    },
+    "sender" : {
+        "address" :  "sender@domain.test"
+    },
+    "subject" : "Hello From Amazon WorkMail!",
+    "messageId": "00000000-0000-0000-0000-000000000000",
+    "invocationId": "0000000000000000000000000000000000000000",
+    "flowDirection": "INBOUND",
+    "truncated": false
+}


### PR DESCRIPTION
This application helps you protect Amazon WorkMail Groups within your organization from email storms. It is built on top of the Run Lambda Email Flow Rules for Amazon WorkMail.

It is also a useful starting point for developers interested in making new synchronous Lambdas using Javascript.
See https://docs.aws.amazon.com/workmail/latest/adminguide/lambda.html#synchronous-rules and README.md for more details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
